### PR TITLE
Fixed UI for Scrolling Credits

### DIFF
--- a/00 Unity Proj/Bubble/Assets/Scenes/Credits.unity
+++ b/00 Unity Proj/Bubble/Assets/Scenes/Credits.unity
@@ -205,7 +205,6 @@ GameObject:
   - component: {fileID: 45801892}
   - component: {fileID: 45801894}
   - component: {fileID: 45801893}
-  - component: {fileID: 45801895}
   m_Layer: 5
   m_Name: Background
   m_TagString: Untagged
@@ -270,29 +269,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 45801891}
   m_CullTransparentMesh: 1
---- !u!320 &45801895
-PlayableDirector:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 45801891}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_PlayableAsset: {fileID: 11400000, guid: 7368ec7403b301d4b8e00717a9d77605, type: 2}
-  m_InitialState: 1
-  m_WrapMode: 2
-  m_DirectorUpdateMode: 1
-  m_InitialTime: 0
-  m_SceneBindings:
-  - key: {fileID: 1456980148936136625, guid: 7368ec7403b301d4b8e00717a9d77605, type: 2}
-    value: {fileID: 1907554893}
-  - key: {fileID: 4774114180045068581, guid: 7368ec7403b301d4b8e00717a9d77605, type: 2}
-    value: {fileID: 1454162853}
-  - key: {fileID: 1449782572317327183, guid: 7368ec7403b301d4b8e00717a9d77605, type: 2}
-    value: {fileID: 511999231}
-  m_ExposedReferences:
-    m_References: []
 --- !u!1 &252373368
 GameObject:
   m_ObjectHideFlags: 0
@@ -387,6 +363,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 1578518284}
   - {fileID: 45801892}
   - {fileID: 1907554890}
   - {fileID: 1454162851}
@@ -844,14 +821,14 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 252373372}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.0000038147, y: -1712.8}
-  m_SizeDelta: {x: 937.67, y: 676.3329}
+  m_AnchoredPosition: {x: 0.000013351, y: -3441}
+  m_SizeDelta: {x: 1897.081, y: 1368.347}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &1454162853
 Animator:
@@ -931,6 +908,61 @@ PlayableDirector:
     value: {fileID: 1454162853}
   m_ExposedReferences:
     m_References: []
+--- !u!1 &1578518283
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1578518284}
+  - component: {fileID: 1578518285}
+  m_Layer: 0
+  m_Name: CreditsTimeline
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1578518284
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1578518283}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 348.27054, y: -1077.8723, z: -4.869928}
+  m_LocalScale: {x: 2.8656714, y: 2.8656714, z: 2.8656714}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 252373372}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!320 &1578518285
+PlayableDirector:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1578518283}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_PlayableAsset: {fileID: 11400000, guid: 7368ec7403b301d4b8e00717a9d77605, type: 2}
+  m_InitialState: 1
+  m_WrapMode: 2
+  m_DirectorUpdateMode: 1
+  m_InitialTime: 0
+  m_SceneBindings:
+  - key: {fileID: 1456980148936136625, guid: 7368ec7403b301d4b8e00717a9d77605, type: 2}
+    value: {fileID: 1907554893}
+  - key: {fileID: 4774114180045068581, guid: 7368ec7403b301d4b8e00717a9d77605, type: 2}
+    value: {fileID: 1454162853}
+  - key: {fileID: 1449782572317327183, guid: 7368ec7403b301d4b8e00717a9d77605, type: 2}
+    value: {fileID: 511999231}
+  m_ExposedReferences:
+    m_References: []
 --- !u!1 &1907554889
 GameObject:
   m_ObjectHideFlags: 0
@@ -961,14 +993,14 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 252373372}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.0000076293945, y: -826.8195}
-  m_SizeDelta: {x: 991.8611, y: 1095.6389}
+  m_AnchoredPosition: {x: -0.000015259, y: -1648.5}
+  m_SizeDelta: {x: 2006.72, y: 2216.682}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1907554891
 MonoBehaviour:

--- a/00 Unity Proj/Bubble/Assets/Scenes/Timeline/CreditsTimeline.playable
+++ b/00 Unity Proj/Bubble/Assets/Scenes/Timeline/CreditsTimeline.playable
@@ -111,17 +111,17 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: -826.8195
+        value: -1648.5
         inSlope: 0
-        outSlope: 166.10854
+        outSlope: 333.24286
         tangentMode: 69
         weightedMode: 0
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 14
-        value: 1498.7
-        inSlope: 166.10854
+        value: 3016.9
+        inSlope: 333.24286
         outSlope: 0
         tangentMode: 69
         weightedMode: 0
@@ -131,6 +131,27 @@ AnimationClip:
       m_PostInfinity: 2
       m_RotationOrder: 4
     attribute: m_AnchoredPosition.y
+    path: 
+    classID: 224
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 14
+        value: -0.000015259
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 69
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_AnchoredPosition.x
     path: 
     classID: 224
     script: {fileID: 0}
@@ -146,6 +167,15 @@ AnimationClip:
     - serializedVersion: 2
       path: 0
       attribute: 538195251
+      script: {fileID: 0}
+      typeID: 224
+      customType: 28
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    - serializedVersion: 2
+      path: 0
+      attribute: 1460864421
       script: {fileID: 0}
       typeID: 224
       customType: 28
@@ -180,17 +210,17 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: -826.8195
+        value: -1648.5
         inSlope: 0
-        outSlope: 166.10854
+        outSlope: 333.24286
         tangentMode: 69
         weightedMode: 0
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 14
-        value: 1498.7
-        inSlope: 166.10854
+        value: 3016.9
+        inSlope: 333.24286
         outSlope: 0
         tangentMode: 69
         weightedMode: 0
@@ -200,6 +230,27 @@ AnimationClip:
       m_PostInfinity: 2
       m_RotationOrder: 4
     attribute: m_AnchoredPosition.y
+    path: 
+    classID: 224
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 14
+        value: -0.000015259
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 69
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_AnchoredPosition.x
     path: 
     classID: 224
     script: {fileID: 0}
@@ -288,17 +339,17 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: -1712.8
+        value: -3441
         inSlope: 0
-        outSlope: 166.105
+        outSlope: 333.24286
         tangentMode: 69
         weightedMode: 0
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 14
-        value: 612.67
-        inSlope: 166.105
+        value: 1224.4
+        inSlope: 333.24286
         outSlope: 0
         tangentMode: 69
         weightedMode: 0
@@ -357,17 +408,17 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: -1712.8
+        value: -3441
         inSlope: 0
-        outSlope: 166.105
+        outSlope: 333.24286
         tangentMode: 69
         weightedMode: 0
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 14
-        value: 612.67
-        inSlope: 166.105
+        value: 1224.4
+        inSlope: 333.24286
         outSlope: 0
         tangentMode: 69
         weightedMode: 0


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`fix/credits-ui-cards`](https://github.com/Nicole-Scalera/Bubble/tree/fix/credits-ui-cards) into [`dev`](https://github.com/Atomic-Atlas/MaS/tree/dev).
- This pull only regards one commit made to the Credits sequence.

### In-depth Details
- Following #21, I went ahead and resized the credits cards in the Canvas.
     - This corresponds to 59abdef4ce972a8ee36d367be994511dd656ad91, which fixed the problem of the UI in the final build being drastically smaller than what was depicted in the Unity editor.
- Likewise, the UI in this scene has been adjusted to match the correct 1920 by 1080 resolution.
- This also meant adjusting the animation of their y-axis positions, since they are now larger.
- Additionally, the Timeline for the credits sequence was moved to a new game object named CreditsTimeline.
- You can read more about it in the [commit description](https://github.com/Nicole-Scalera/Bubble/commit/408d4e85a5c56940cb6ee8b91f3cfbaf9a5be8d6).