### PR TITLE
Resolved NullReferenceException Error in GameManager.cs:47

### DIFF
--- a/00 Unity Proj/Bubble/Assets/Scenes/Features/TestOfObstacles.unity
+++ b/00 Unity Proj/Bubble/Assets/Scenes/Features/TestOfObstacles.unity
@@ -2303,6 +2303,7 @@ GameObject:
   - component: {fileID: 1736546676}
   - component: {fileID: 1736546675}
   - component: {fileID: 1736546674}
+  - component: {fileID: 1736546678}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -2462,6 +2463,19 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1934345035}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1736546678
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1736546672}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 377afd4c7503ef04e98d7f11a2af2f60, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cameraPosition: {x: 0, y: 0}
 --- !u!1 &1827259534
 GameObject:
   m_ObjectHideFlags: 0
@@ -2642,9 +2656,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c41ac4ddb0894524b8d9bcc5d4ce3d67, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playerObject: {fileID: 1165274842}
-  targetObject: {fileID: 245931440}
-  mainCamera: {fileID: 1736546672}
+  cameraInfo: {fileID: 0}
 --- !u!4 &1858419706
 Transform:
   m_ObjectHideFlags: 0
@@ -2781,10 +2793,10 @@ SpriteRenderer:
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
+  - {fileID: 1858419706}
   - {fileID: 1934345035}
   - {fileID: 268173020}
   - {fileID: 1165274843}
-  - {fileID: 1858419706}
   - {fileID: 474742798}
   - {fileID: 1827259539}
   - {fileID: 304999620}

--- a/00 Unity Proj/Bubble/Assets/Scripts/Camera/CameraInfo.cs
+++ b/00 Unity Proj/Bubble/Assets/Scripts/Camera/CameraInfo.cs
@@ -20,7 +20,15 @@ public class CameraInfo : MonoBehaviour
     [SerializeField] private Vector2 cameraPosition; // Coordinates of the Camera (X,Y)
     // ^^^ Serializing to view
     // in the Inspector
+    private Camera camComponent; // Camera component attached to the GameObject
     // =====================
+
+    // Get the Camera component on the object
+    public Camera GetCameraComponent()
+    {
+        camComponent = GetComponent<Camera>();
+        return camComponent;
+    }
 
     // Get the Camera's location in the scene
     public Vector2 GetCameraPosition()

--- a/00 Unity Proj/Bubble/Assets/Scripts/Game/GameManager.cs
+++ b/00 Unity Proj/Bubble/Assets/Scripts/Game/GameManager.cs
@@ -6,12 +6,19 @@ public class GameManager : MonoBehaviour
     // that we can easily access it anywhere
     public static GameManager Instance;
 
+    // ===== Script References =====
+    public CameraInfo cameraInfo; // CameraInfo.cs
+    // =============================
+
+    // ===== Variables/Components =====
     // Create References to relevant GameObjects
-    public GameObject playerObject; // Player
-    public GameObject targetObject; // Target
-    public GameObject mainCamera; // Main Camera
+    private GameObject playerObject; // Player
+    private GameObject targetObject; // Target
+    private GameObject cameraGO; // Camera GameObject
+    private Camera mainCamera; // Actual Main Camera
     private Vector2 mainCameraPos; // Camera's Current Location
-    private CameraInfo cameraInfo; // CameraInfo.cs
+    // ================================
+
 
     private void Awake()
     {
@@ -35,8 +42,8 @@ public class GameManager : MonoBehaviour
 
 
         // ===== Main Camera =====
-        mainCamera = GameObject.Find("Main Camera"); // Assign Main Camera
-        cameraInfo = mainCamera.GetComponent<CameraInfo>(); // Access CameraInfo.cs
+        cameraGO = GameObject.Find("Main Camera"); // Assign Main Camera
+        cameraInfo = cameraGO.GetComponent<CameraInfo>(); // Access CameraInfo.cs
         GetCameraInfo();
     }
 
@@ -44,13 +51,15 @@ public class GameManager : MonoBehaviour
     public void GetCameraInfo()
     {
         // Get the following information about the Camera
+        mainCamera = cameraInfo.GetCameraComponent(); // Camera Component
         mainCameraPos = cameraInfo.GetCameraPosition(); // Camera's Position
     }
 
-    void Update() {
+    void Update()
+    {
         // For Debugging:
         GetCameraInfo();
         Debug.Log($"GameManager.cs > Update(): Camera's position is ({mainCameraPos.x}, {mainCameraPos.y})");
     }
-    
+
 }

--- a/00 Unity Proj/Bubble/Assets/Scripts/Game/ObjectCollision.cs
+++ b/00 Unity Proj/Bubble/Assets/Scripts/Game/ObjectCollision.cs
@@ -7,7 +7,7 @@
 
 using UnityEngine;
 
-public class CollisionTrigger : MonoBehaviour
+public class ObjectCollision : MonoBehaviour
 {
     public SceneChanger sceneChanger; // Reference to the SceneChanger script
     private string sceneName;

--- a/00 Unity Proj/Bubble/Assets/Scripts/Game/SceneChanger.cs
+++ b/00 Unity Proj/Bubble/Assets/Scripts/Game/SceneChanger.cs
@@ -1,16 +1,27 @@
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
+// This is the SceneChanger class. When called, it will change
+// the current scene to a new one of a specific name. Set the
+// name in the Inspector, or create a line to manually assign
+// it through the code.
+
 public class SceneChanger : MonoBehaviour
 {
-
+    // Current instance of the sceneName
     private string sceneName;
 
     public void LoadScene(string sceneName)
     {
         this.sceneName = sceneName;
+    //  ^^^
+    //  Use keyword "this" assign the name
+    //  to the specific instance of sceneName
+
+        // Tell the user what scene is being loaded
         Debug.Log($"Loading scene: {sceneName}");
-        // Load a different scene by name
+        
+        // Load a scene by its name
         SceneManager.LoadScene(sceneName);
     }
 }


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`fix/collision-detection`](https://github.com/Nicole-Scalera/Bubble/tree/fix/collision-detection) into [`feat/collision-detection`](https://github.com/Nicole-Scalera/Bubble/tree/feat/collision-detection).
- This directly follows the closure of #32 in b79ac37.

### In-depth Details
- This PR mainly regards the [component-reference error](https://github.com/users/Nicole-Scalera/projects/1/views/1?pane=issue&itemId=97023915&issue=Nicole-Scalera%7CBubble%7C32) in the GameManager.cs file.
- Specifically, regarding the Main Camera in the scene.
- I will break down the details below.

#### A. History
- In 086a796, I implemented a [Virtual Camera](https://docs.unity3d.com/Packages/com.unity.cinemachine@2.8/manual/CinemachineSetUpVCam.html) that would control the Main Camera in the scene, so as to make it follow the Player object as it floated up.
- Then, in 6525b23, I tweaked some settings that locked the Main Camera in the x-axis.
     - i.e. it only follows the Player vertically.
- @Samisushi suggested this change, as it would keep the camera from reaching outside of the artwork.
     - I will need to add barriers on the sides eventually.


#### B. Debugging
- To ensure the Main Camera was locked, I had the GameManager grab data from CameraInfo.cs and print it out (6525b23).
- At the time, I was certain everything was stable, but I must've overlooked an error that ended up being pushed to @Annadaliah's side on [`feat/collision-detection`](https://github.com/Nicole-Scalera/Bubble/tree/feat/collision-detection).
- This morning, @Annadaliah pointed out the following bug, and we got together to fix it.

<p>
<img src="https://github.com/user-attachments/assets/d4425994-b830-4116-b577-5abfe8c17b28" alt="NullReferenceException Thrown - GameManager.cs:47" width="100%" style="max-width: 100%;">
</p>

#### C. Identifying the Issue
- @Annadaliah [pushed her changes](https://github.com/Nicole-Scalera/Bubble/commit/e53df87b0dab7872af67b0d9d39dfc1032dbfa95), to which I branched off to create [`fix/collision-detection`](https://github.com/Nicole-Scalera/Bubble/tree/fix/collision-detection).
- After much trial and error, we realized that, inside of the GameManager game object's Inspector menu, the Main Camera was not being assigned correctly.

#### D. Fixing the Issue
- I started by copying the backgroundInfo's GetEventCamera() method into cameraInfo.cs.
     - This allows Unity to specifically grab the [Camera component](https://docs.unity3d.com/6000.0/Documentation/ScriptReference/Camera.html) attached to the Main Camera game object in the scene.
     - Renamed it to "GetCameraComponent".
- Next, I replicated logic from Parallax.cs, which obtains the Main Camera from backgroundInfo using a method called GetCanvasInfo (776b6b7).
     - Renamed it "GetCameraInfo".
- In GameManager.cs, I altered my set of variables.
     - mainCamera's datatype changed from **GameObject** to **Camera**.
          - That is because we're looking for the Camera component, not just the game object named Main Camera.
     - Created cameraGO to identify the Main Camera game object.
- Lastly, I created a reference to the cameraInfo script to gather all of this data.

#### E. Current Status
- The Camera component on the Main Camera game object is now correctly linked to GameManager.cs
     - Through the debugger, you'll find that the Main Camera's y-axis is constantly changing, but the x-axis remains 0.
- Although the code definitely needs to be cleaned up, it is currently free of errors.
- While on call with @Annadaliah, I sketched out the following graph to show how I would fix the camera error no my end, and then push it to her.
     - i.e. I purposefully created and committed to the new "fix" branch rather than potentially messing with her progress on the "feature" branch.