### PR TITLE
Fixed #88 | Player Collides with Scene Barriers

### DIFF
--- a/00 Unity Proj/Bubble/Assets/Scenes/Level1.unity
+++ b/00 Unity Proj/Bubble/Assets/Scenes/Level1.unity
@@ -137,7 +137,6 @@ GameObject:
   m_Component:
   - component: {fileID: 161316261}
   - component: {fileID: 161316262}
-  - component: {fileID: 161316263}
   - component: {fileID: 161316264}
   m_Layer: 0
   m_Name: barrier_R
@@ -213,33 +212,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!50 &161316263
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 161316260}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0
-  m_GravityScale: 0
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
 --- !u!61 &161316264
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -269,7 +241,7 @@ BoxCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
@@ -1389,7 +1361,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1145843114}
   - component: {fileID: 1145843113}
-  - component: {fileID: 1145843115}
   - component: {fileID: 1145843116}
   m_Layer: 0
   m_Name: barrier_L
@@ -1465,33 +1436,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1353930442}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!50 &1145843115
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1145843112}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0
-  m_GravityScale: 0
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
 --- !u!61 &1145843116
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -1521,7 +1465,7 @@ BoxCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`issue/88-barrier-collision`](https://github.com/Nicole-Scalera/Bubble) into [`dev`](https://github.com/Nicole-Scalera/Bubble/tree/dev).
- This PR closes #88.

### In-depth Details
- The Player now collides with the blue Scene Barriers that were implemented back in [#82](https://github.com/Nicole-Scalera/Bubble/pull/82).
- This issue stemmed from the changes introduced in [#62](https://github.com/Nicole-Scalera/Bubble/issues/62).
     - I made the Player **static** and instead moved the rest of the environment.
- In short, I made the following changes to the barriers:
     - Removed Rigidbody2D component
     - Unchecked IsTrigger variable from colliders
- For more information, see [#88](https://github.com/Nicole-Scalera/Bubble/issues/88) and 96fe23d.

<p>
<video src="https://github.com/user-attachments/assets/01f37f20-cfad-4ddb-a1d1-d9705f61dce3" alt="PlayerCollisionSceneBarriers" width="100%" style="max-width: 100%;">
</p>